### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ sql("""SELECT name, COUNT(recipient) FROM
 ```
 
 The last example will generate a list of pairs of usernames and
-counts, correponding to the number of messages that user has sent.
+counts, corresponding to the number of messages that user has sent.
 
 Mixing SQL and other Spark operations
 -------------------------------------


### PR DESCRIPTION
@AndreSchumacher, I've corrected a typographical error in the documentation of the [avro-parquet-spark-example](https://github.com/AndreSchumacher/avro-parquet-spark-example) project. Specifically, I've changed correponding to corresponding. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
